### PR TITLE
Fix data races in test runner

### DIFF
--- a/test/loop.cpp
+++ b/test/loop.cpp
@@ -19,7 +19,7 @@
 
 #define BATCHTIMES
 
-extern TestTimer timer;
+extern thread_local TestTimer timer;
 
 
 void loop_solve(std::ostream &out,

--- a/test/print.cpp
+++ b/test/print.cpp
@@ -8,6 +8,7 @@
 */
 
 
+#include <array>
 #include <iostream>
 #include <iomanip>
 #include <algorithm>
@@ -16,54 +17,49 @@
 #include "cst.h"
 
 
-static unsigned short dbitMapRank[16];
-static unsigned char dcardRank[16];
-static unsigned char dcardSuit[5];
+static const std::array<unsigned short, 16> dbitMapRank{
+  0x0000,
+  0x0000,
+  0x0001,
+  0x0002,
+  0x0004,
+  0x0008,
+  0x0010,
+  0x0020,
+  0x0040,
+  0x0080,
+  0x0100,
+  0x0200,
+  0x0400,
+  0x0800,
+  0x1000,
+  0x2000,
+};
+static const std::array<unsigned char, 16> dcardRank{
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  'T',
+  'J',
+  'Q',
+  'K',
+  'A',
+  '-'
+};
+static const std::array<unsigned char, 5> dcardSuit{
+  'S',
+  'H',
+  'D',
+  'C',
+  'N'
+};
 
 std::string equals_to_string(const int equals);
-
-
-void set_constants()
-{
-  dbitMapRank[15] = 0x2000;
-  dbitMapRank[14] = 0x1000;
-  dbitMapRank[13] = 0x0800;
-  dbitMapRank[12] = 0x0400;
-  dbitMapRank[11] = 0x0200;
-  dbitMapRank[10] = 0x0100;
-  dbitMapRank[ 9] = 0x0080;
-  dbitMapRank[ 8] = 0x0040;
-  dbitMapRank[ 7] = 0x0020;
-  dbitMapRank[ 6] = 0x0010;
-  dbitMapRank[ 5] = 0x0008;
-  dbitMapRank[ 4] = 0x0004;
-  dbitMapRank[ 3] = 0x0002;
-  dbitMapRank[ 2] = 0x0001;
-  dbitMapRank[ 1] = 0;
-  dbitMapRank[ 0] = 0;
-
-  dcardRank[ 2] = '2';
-  dcardRank[ 3] = '3';
-  dcardRank[ 4] = '4';
-  dcardRank[ 5] = '5';
-  dcardRank[ 6] = '6';
-  dcardRank[ 7] = '7';
-  dcardRank[ 8] = '8';
-  dcardRank[ 9] = '9';
-  dcardRank[10] = 'T';
-  dcardRank[11] = 'J';
-  dcardRank[12] = 'Q';
-  dcardRank[13] = 'K';
-  dcardRank[14] = 'A';
-  dcardRank[15] = '-';
-
-  dcardSuit[0] = 'S';
-  dcardSuit[1] = 'H';
-  dcardSuit[2] = 'D';
-  dcardSuit[3] = 'C';
-  dcardSuit[4] = 'N';
-}
-
 
 void print_PBN(std::ostream &out, const dealPBN& dl)
 {

--- a/test/print.h
+++ b/test/print.h
@@ -16,8 +16,6 @@
 #include "dll.h"
 
 
-void set_constants();
-
 void print_PBN(std::ostream &out, const dealPBN& dl);
 
 void print_FUT(std::ostream &out, const futureTricks& fut);

--- a/test/testcommon.cpp
+++ b/test/testcommon.cpp
@@ -80,7 +80,6 @@ int realMain(const std::string& fname, Solver solver)
   else if (solver == DTEST_SOLVER_DEALERPAR)
     stepsize = 1;
 
-  set_constants();
   main_identify(out);
 
   int number;

--- a/test/testcommon.cpp
+++ b/test/testcommon.cpp
@@ -50,7 +50,7 @@ const std::array<std::string, 5> DDS_SYSTEM_COMPILER =
 
 
 extern OptionsType options;
-TestTimer timer;
+thread_local TestTimer timer;
 
 
 void main_identify(std::ostream& ostream);


### PR DESCRIPTION
## Make test timer thread local

The thread timer global causes data races when executing more than one
test thread. Simplest modification is to make the timer thread local
which creates a new object for each thread automatically.

## Initialize helper lookup tables statically

Runtime function initializing arrays causes data races when running test
in multiple threads. To avoid race conditions lookup tables can be
initialized statically.